### PR TITLE
0.0.5 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <img src="https://i.imgur.com/yCAmIp8.png" alt="Picture Perfect Logo" />
 
-# Picture Perfect 0.0.4 ALPHA
+# Picture Perfect 0.0.5 ALPHA
 for MyBB 1.8.x
 
 *make your MyBB forum images just right*
@@ -13,5 +13,7 @@ This plugin allows you to view all of the posted images on your forum, perform i
 - rehost images on your forum locally
 - rehost images on your forum on **Imgur**
 - view and manage image sets (currently only thumbnails)
+- create image tasks with predefined settings
+- create task lists and batch process images
 
 This alpha release is intended to gather user feedback to determine which features are the most useful to MyBB admins.

--- a/Upload/inc/languages/english/admin/pp.lang.php
+++ b/Upload/inc/languages/english/admin/pp.lang.php
@@ -25,7 +25,7 @@ $l['pp_inline_title'] = 'Inline Edits';
 /* install */
 
 $l['pp_installation'] = 'Picture Perfect Installation';
-$l['pp_finalizing_installation'] = 'Installation almost completed. Analyzing your forum\'s posted images. Please be patient. On larger forums, this might take a while...';
+$l['pp_finalizing_installation'] = 'Component installation completed.';
 $l['pp_finalize_installation'] = 'Finalize Installation';
 $l['pp_analyze_posted_images'] = 'Analyze Posted Images';
 $l['pp_analyze_posted_images_description'] = 'Collect and store information about the posted images on your forum.';

--- a/Upload/inc/languages/english/pp.lang.php
+++ b/Upload/inc/languages/english/pp.lang.php
@@ -1,0 +1,12 @@
+<?php
+/*
+ * Plugin Name: Picture Perfect for MyBB 1.8.x
+ * Copyright 2018 WildcardSearch
+ * http://www.rantcentralforums.com
+ *
+ * ACP language file
+ */
+
+$l['pp'] = 'Picture Perfect';
+
+?>

--- a/Upload/inc/plugins/pp.php
+++ b/Upload/inc/plugins/pp.php
@@ -12,7 +12,7 @@ if (!defined('IN_MYBB')) {
     die('Direct initialization of this file is not allowed.<br /><br />Please make sure IN_MYBB is defined.');
 }
 
-define('PICTURE_PERFECT_VERSION', '0.0.4');
+define('PICTURE_PERFECT_VERSION', '0.0.5');
 define('PICTURE_PERFECT_MOD_URL', MYBB_ROOT.'inc/plugins/pp/modules');
 
 // register custom class autoloader

--- a/Upload/inc/plugins/pp/acp.php
+++ b/Upload/inc/plugins/pp/acp.php
@@ -77,7 +77,7 @@ function pp_admin_main()
 		$forum = get_forum($fid);
 	}
 
-	$page->add_breadcrumb_item($lang->pp_admin_main);
+	$page->add_breadcrumb_item($lang->pp);
 
 	// set up the page header
 	$page->extra_header .= <<<EOF
@@ -118,7 +118,10 @@ function pp_admin_view_threads()
 		$forum = get_forum($fid);
 	}
 
-	$page->add_breadcrumb_item($lang->pp_admin_main);
+	$forumName = htmlspecialchars_uni($forum['name']);
+
+	$page->add_breadcrumb_item($lang->pp);
+	$page->add_breadcrumb_item("View Image Threads in {$forumName}");
 
 	// set up the page header
 	$page->extra_header .= <<<EOF
@@ -254,12 +257,18 @@ function pp_admin_view_thread()
 {
 	global $mybb, $db, $page, $lang, $html, $min, $cp_style, $modules;
 
-	$page->add_breadcrumb_item($lang->pp_admin_view_thread);
-
 	$selected = $mybb->input['selected_ids'];
 	$tid = (int) $mybb->input['tid'];
 	$titleQuery = $db->simple_select('threads', 'subject', "tid={$tid}");
 	$threadTitle = $db->fetch_field($titleQuery, 'subject');
+
+	$shortTitle = $threadTitle;
+	if (my_strlen($shortTitle) > 20) {
+		$shortTitle = my_substr($threadTitle, 17).'...';
+	}
+
+	$page->add_breadcrumb_item($lang->pp);
+	$page->add_breadcrumb_item("{$lang->pp_view_thread} #{$tid} ({$shortTitle})");
 
 	// set up the page header
 	$page->extra_header .= <<<EOF
@@ -637,17 +646,18 @@ function pp_admin_edit_set()
 {
 	global $mybb, $db, $page, $lang, $html, $min;
 
-	$page->add_breadcrumb_item($lang->pp_admin_edit_set);
-
-	$page->output_header("{$lang->pp} - {$lang->pp_admin_edit_set}");
-	pp_output_tabs('pp_edit_set');
-
 	$data = array();
 	$id = (int) $mybb->input['id'];
 	$imageSet = new PicturePerfectImageSet($id);
 	if ($imageSet->isValid()) {
 		$data = $imageSet->get('data');
 	}
+
+	$page->add_breadcrumb_item($lang->pp);
+	$page->add_breadcrumb_item("{$lang->pp_admin_edit_set} #{$id} ({$imageSet->get('title')})");
+
+	$page->output_header("{$lang->pp} - {$lang->pp_admin_edit_set}");
+	pp_output_tabs('pp_edit_set');
 
 	if ($mybb->request_method == 'post') {
 		$imageSet->set($mybb->input);
@@ -684,8 +694,6 @@ function pp_admin_edit_set()
 function pp_admin_view_set()
 {
 	global $mybb, $db, $page, $lang, $html, $min, $cp_style, $modules;
-
-	$page->add_breadcrumb_item($lang->pp_admin_view_set);
 
 	// set up the page header
 	$page->extra_header .= <<<EOF
@@ -729,11 +737,14 @@ function pp_admin_view_set()
 
 EOF;
 
-	$page->output_header("{$lang->pp} - {$lang->pp_admin_view_set}");
-	pp_output_tabs('pp_view_set');
-
 	$id = (int) $mybb->input['id'];
 	$imageSet = new PicturePerfectImageSet($id);
+
+	$page->add_breadcrumb_item($lang->pp);
+	$page->add_breadcrumb_item("{$lang->pp_admin_view_set} #{$id} ({$imageSet->get('title')})");
+
+	$page->output_header("{$lang->pp} - {$lang->pp_admin_view_set}");
+	pp_output_tabs('pp_view_set');
 
 	// get a total count on the items
 	$query = $db->simple_select('pp_images', 'COUNT(id) AS resultCount', "setid={$id}");
@@ -1030,7 +1041,8 @@ function pp_admin_edit_image_task()
 		}
 	}
 
-	$page->add_breadcrumb_item('Edit Image Task');
+	$page->add_breadcrumb_item($lang->pp);
+	$page->add_breadcrumb_item("Edit Image Task #{$id} ({$task->get('title')})");
 
 	$page->output_header("{$lang->pp} - Edit Image Task");
 	pp_output_tabs('pp_edit_image_task');
@@ -1303,7 +1315,8 @@ function pp_admin_edit_image_task_list()
 		}
 	}
 
-	$page->add_breadcrumb_item('Edit Image Task List');
+	$page->add_breadcrumb_item($lang->pp);
+	$page->add_breadcrumb_item("Edit Image Task List #{$id} ({$taskList->get('title')})");
 
 	$page->output_header("{$lang->pp} - Edit Image Task List");
 	pp_output_tabs('pp_edit_image_task_list');

--- a/Upload/inc/plugins/pp/acp.php
+++ b/Upload/inc/plugins/pp/acp.php
@@ -91,6 +91,7 @@ EOF;
 	$table->construct_header('Forum');
 	$table->construct_header('Description');
 	$table->construct_header('Image Count');
+	$table->construct_header('Control');
 
 	ppBuildForumList($table, $fid);
 
@@ -160,8 +161,9 @@ EOF;
 EOF;
 
 	$table = new Table;
-	$table->construct_header($lang->pp_thread, array('width' => '80%'));
+	$table->construct_header($lang->pp_thread, array('width' => '70%'));
 	$table->construct_header($lang->pp_image_count, array('width' => '15%'));
+	$table->construct_header('Controls', array('width' => '10%'));
 	$table->construct_header($form->generate_check_box('', '', '', array('id' => 'pp_select_all')), array('style' => 'width: 1%'));
 
 	// adjust the page number if the user has entered manually or is returning to a page that no longer exists (deleted last item on page)
@@ -206,6 +208,11 @@ EOF;
 		while ($thread = $db->fetch_array($query)) {
 			$table->construct_cell($html->link($html->url(array('action' => 'view_thread', 'tid' => $thread['tid'])), $thread['subject']));
 			$table->construct_cell($thread['image_count']);
+
+			$popup = new PopupMenu("control_{$thread['tid']}", 'Options');
+			$popup->add_item('Scan', $html->url(array('action' => 'scan_center', 'mode' => 'inline', 'tid' => $thread['tid'])));
+			$table->construct_cell($popup->fetch());
+
 			$table->construct_cell($form->generate_check_box("pp_inline_ids[{$thread['tid']}]", '', '', array('class' => 'pp_check')));
 			$table->construct_row();
 
@@ -1309,6 +1316,109 @@ function pp_admin_edit_image_task_list()
 }
 
 /**
+ * scan images selectively
+ *
+ * @return void
+ */
+function pp_admin_scan_center()
+{
+	global $mybb, $db, $page, $lang, $html, $min, $modules;
+
+	$tid = (int) $mybb->input['tid'];
+	$fid = (int) $mybb->input['fid'];
+
+	if ($mybb->request_method == 'post' ||
+		$mybb->input['mode'] == 'inline') {
+		if ($tid) {
+			if ($mybb->input['mode'] != 'override') {
+				$query = $db->simple_select('pp_images', 'id', "tid='{$tid}'");
+
+				if ($db->num_rows($query)) {
+					flash_message('Existing images found for this thread!', 'error');
+					admin_redirect($html->url(array('action' => 'scan_center', 'mode' => 'confirm_overwrite', 'tid' => $tid, 'fid' => $fid)));
+				}
+			}
+
+			$message = "Scan Thread #{$mybb->input['tid']}";
+		} elseif ($fid) {
+			if ($mybb->input['mode'] != 'override') {
+				$query = $db->simple_select('pp_images', 'id', "fid='{$fid}'");
+
+				if ($db->num_rows($query)) {
+					flash_message('Existing images found for this forum!', 'error');
+					admin_redirect($html->url(array('action' => 'scan_center', 'mode' => 'confirm_overwrite', 'tid' => $tid, 'fid' => $fid)));
+				}
+			}
+
+			$message = "Scan Forum #{$mybb->input['fid']}";
+		} else {
+			if ($mybb->input['mode'] != 'override') {
+				$query = $db->simple_select('pp_images', 'id');
+
+				if ($db->num_rows($query)) {
+					flash_message('Existing images found for this site!', 'error');
+					admin_redirect($html->url(array('action' => 'scan_center', 'mode' => 'confirm_overwrite')));
+				}
+			}
+
+			$message = "Scan Entire Forum";
+		}
+
+		$newOnly = (isset($mybb->input['start_new_scan']));
+		$deleteFirst = (isset($mybb->input['start_delete_and_scan']));
+
+		ppInitiateImageScan($message, $mybb->input['fid'], $mybb->input['tid'], $newOnly, $deleteFirst);
+	}
+
+	if ($mybb->input['mode'] == 'confirm_overwrite') {
+		$page->add_breadcrumb_item('Confirm Image Overwrite');
+
+		$page->output_header("{$lang->pp} - Image Scan Center");
+		pp_output_tabs('pp_confirm_overwrite');
+
+		echo <<<EOF
+<div style="width: 60%; border-radius: 6px; border: 1px solid gray; background: pink; text-align: center; padding: 20px; margin: 20px auto;">
+	<span style="font-size: 1.4em">The thread or folder you have chosen to be scanned already has existing images. Scanning again may produce duplicate records unless you choose to only look for new images.</span>
+</div>
+EOF;
+
+		$form = new Form($html->url(array('action' => 'scan_center', 'mode' => 'override')), 'post');
+
+		echo($form->generate_hidden_field('tid', $tid));
+		echo($form->generate_hidden_field('fid', $fid));
+
+		$buttons[] = $form->generate_submit_button('Scan All Images (not recommended)', array('name' => 'start_full_scan'));
+		$buttons[] = $form->generate_submit_button('Scan Only New Images', array('name' => 'start_new_scan'));
+		$buttons[] = $form->generate_submit_button('Delete Existing Images And Start Over', array('name' => 'start_delete_and_scan'));
+		$form->output_submit_wrapper($buttons);
+		$form->end();
+
+		$page->output_footer();
+		exit;
+	}
+
+	$page->add_breadcrumb_item('Image Scan Center');
+
+	$page->output_header("{$lang->pp} - Image Scan Center");
+	pp_output_tabs('pp_scan_center');
+
+	$form = new Form($html->url(array('action' => 'scan_center')), 'post');
+
+	$formContainer = new FormContainer();
+
+	$formContainer->output_row('Thread ID', '', $form->generate_text_box('tid'));
+	$formContainer->output_row('Forum ID', '', $form->generate_text_box('fid'));
+
+	$formContainer->end();
+
+	$buttons[] = $form->generate_submit_button('Start Scan', array('name' => 'start_image_scan'));
+	$form->output_submit_wrapper($buttons);
+	$form->end();
+
+	$page->output_footer();
+}
+
+/**
  * merge new images into an existing task list
  *
  * @return void
@@ -1564,11 +1674,42 @@ function pp_admin_config_plugins_activate_commit() {
 		$lang->load('pp');
 	}
 
-	$query = $db->simple_select('posts', 'pid');
-	$count = (int) $db->num_rows($query);
+	ppInitiateImageScan($lang->pp_finalizing_installation);
+}
 
-	flash_message($lang->pp_finalizing_installation, 'success');
-	admin_redirect("index.php?module=config-pp&action=scan&count={$count}");
+function ppInitiateImageScan($message, $fid=0, $tid=0, $newOnly=false, $deleteFirst=false)
+{
+	global $db;
+
+	$fid = (int) $fid;
+	$tid = (int) $tid;
+
+	$where = $queryExtra = '';
+	if ($tid) {
+		$queryExtra = "&tid={$tid}";
+		$where = "tid='{$tid}'";
+	} elseif($fid) {
+		$queryExtra = "&fid={$fid}";
+		$where = "fid='{$fid}'";
+	}
+
+	if ($deleteFirst) {
+		$db->delete_query('pp_images', $where);
+		$db->delete_query('pp_image_threads', $where);
+	} elseif ($newOnly) {
+		$query = $db->simple_select('pp_images', 'pid', $where, array('order_by' => 'pid', 'order_dir' => 'DESC', 'limit' => 1));
+
+		$lastPid = (int) $db->fetch_field($query, 'pid');
+		$where .= " AND pid > {$lastPid}";
+
+		$queryExtra .= "&lastpid={$lastPid}";
+	}
+
+	$query = $db->simple_select('posts', 'COUNT(pid) as resultCount', $where);
+	$count = (int) $db->fetch_field($query, 'resultCount');
+
+	flash_message($message, 'success');
+	admin_redirect("index.php?module=config-pp&action=scan&count={$count}{$queryExtra}");
 }
 
 /**
@@ -1583,18 +1724,36 @@ function pp_admin_scan()
 		return false;
 	}
 
+	if (isset($mybb->input['do_not_analyze_posts'])) {
+		$warning = '<br /><br />Skipping the image scan means that you will not see any images in the ACP interface. You will need to scan images from your forum\'s post before you can begin to use the plugin image processing modules.';
+		flash_message($lang->pp_installation_finished.$warning, 'success');
+		admin_redirect('index.php?module=config-plugins');
+	}
+
 	if (!$lang->pp) {
 		$lang->load('pp');
 	}
 
 	$inProgress = (int) $mybb->input['in_progress'];
 	$start = (int) $mybb->input['start'];
+
 	$ppp = (int) $mybb->input['posts_per_page'];
 	if ($ppp == 0) {
 		$ppp = 10000;
 	}
+
 	$totalCount = (int) $mybb->input['count'];
 
+	if (!$totalCount) {
+		flash_message('No images to scan.', 'error');
+		admin_redirect('index.php?module=config-pp&action=scan_center');
+	}
+
+	$fid = (int) $mybb->input['fid'];
+	$tid = (int) $mybb->input['tid'];
+	$lastPid = (int) $mybb->input['lastpid'];
+	
+	
 	if ($mybb->request_method == 'post') {
 		$threadCache = $cache->read('pp_thread_cache');
 
@@ -1605,7 +1764,20 @@ function pp_admin_scan()
 
 		$done = false;
 
-		$query = $db->simple_select('posts', 'pid, tid, fid, message', '', array('limit' => $ppp, 'limit_start' => $start, 'order_by' => 'dateline', 'order_dir', 'ASC'));
+		$operator = $where = '';
+		if ($tid) {
+			$where = "tid='{$tid}'";
+			$operator = ' AND ';
+		} elseif ($fid) {
+			$where = "fid='{$fid}'";
+			$operator = ' AND ';
+		}
+
+		if ($lastPid) {
+			$where .= "{$operator}pid > {$lastPid}";
+		}
+
+		$query = $db->simple_select('posts', 'pid, tid, fid, message', $where, array('limit' => $ppp, 'limit_start' => $start, 'order_by' => 'dateline', 'order_dir', 'ASC'));
 
 		$count = $db->num_rows($query);
 		if ($count == 0 ||
@@ -1638,11 +1810,11 @@ function pp_admin_scan()
 
 			foreach ($threadCache as $key => $count) {
 				$keyPieces = explode('-', $key);
-				list($fid, $tid) = $keyPieces;
+				list($forumId, $threadId) = $keyPieces;
 				
 				$insert_arrays[] = array(
-					'tid' => (int) $tid,
-					'fid' => (int) $fid,
+					'tid' => (int) $threadId,
+					'fid' => (int) $forumId,
 					'image_count' => (int) $count,
 					'dateline' => TIME_NOW,
 				);
@@ -1654,8 +1826,18 @@ function pp_admin_scan()
 
 			$cache->update('pp_thread_cache', null);
 
-			flash_message($lang->pp_installation_finished, 'success');
-			admin_redirect('index.php?module=config-plugins');
+			$message = $lang->pp_installation_finished;
+			$redirect = 'index.php?module=config-plugins';
+			if ($tid) {
+				$message = 'Thread scanned successfully.';
+				$redirect = "index.php?module=config-pp&action=view_thread&tid={$tid}";
+			} elseif ($fid) {
+				$message = 'Forum scanned successfully.';
+				$redirect = 'index.php?module=config-pp';
+			}
+
+			flash_message($message, 'success');
+			admin_redirect($redirect);
 		}
 
 		$start += $ppp;
@@ -1678,26 +1860,26 @@ EOF;
 
 	$page->output_header("{$lang->pp} - {$lang->pp_installation}");
 
-	if ($inProgress) {
-		$message = $lang->sprintf($lang->pp_installation_progress, $start, $totalCount);
-		$info = <<<EOF
+	$message = $lang->sprintf($lang->pp_installation_progress, $start, $totalCount);
+	$info = <<<EOF
 <div style="width: 100%; height: 40px; background: #f2f2f2; text-align: center; font-weight: bold;">
-	<h1>{$message}</h1>
+<h1>{$message}</h1>
 <div>
 EOF;
-		echo($info);
-	}
+	echo($info);
 
 	$form = new Form('index.php?module=config-pp', 'post');
 
 	$form_container = new FormContainer($lang->pp_analyze_posted_images);
-	$form_container->output_row_header($lang->name);
-	$form_container->output_row_header($lang->pp_posts_per_page, array('width' => 50));
-	$form_container->output_row_header('&nbsp;');
+	$form_container->output_row_header('Task', array('width' => '60%'));
+	$form_container->output_row_header($lang->pp_posts_per_page, array('width' => '20%'));
+	$form_container->output_row_header('&nbsp;', array('width' => '5%'));
+	$form_container->output_row_header('&nbsp;', array('width' => '10%'));
 
 	$form_container->output_cell("<label>{$lang->pp_analyze_posted_images}</label><div class=\"description\">{$lang->pp_analyze_posted_images_description}</div>");
 	$form_container->output_cell($form->generate_numeric_field('posts_per_page', $ppp, array('style' => 'width: 150px;', 'min' => 0)));
-	$form_container->output_cell($form->generate_submit_button($lang->go, array('name' => 'analyze_posts', 'class' => 'button_yes', 'id' => 'analyze_submit')).$form->generate_hidden_field('start', $start).$form->generate_hidden_field('count', $totalCount).$form->generate_hidden_field('in_progress', 1).$form->generate_hidden_field('action', 'scan'));
+	$form_container->output_cell($form->generate_submit_button($lang->go, array('name' => 'analyze_posts', 'class' => 'button_yes', 'id' => 'analyze_submit')));
+	$form_container->output_cell($form->generate_submit_button('Skip for now...', array('name' => 'do_not_analyze_posts', 'class' => 'button_no', 'id' => 'skip_submit')).$form->generate_hidden_field('start', $start).$form->generate_hidden_field('count', $totalCount).$form->generate_hidden_field('in_progress', 1).$form->generate_hidden_field('action', 'scan').$form->generate_hidden_field('fid', $fid).$form->generate_hidden_field('tid', $tid).$form->generate_hidden_field('lastpid', $lastPid));
 	$form_container->construct_row();
 
 	$form_container->end();
@@ -1796,6 +1978,15 @@ function pp_output_tabs($current, $threadTitle='', $tid=0)
 			'description' => 'configure image task details',
 		);
 		break;
+	case 'pp_confirm_overwrite':
+		$urlArray = array('action' => 'scan_center', 'mode' => 'confirm_overwrite');
+
+		$subTabs['pp_confirm_overwrite'] = array(
+			'title' => 'Confirm Image Overwrite',
+			'link' => $html->url($urlArray),
+			'description' => 'The thread or forum being scanned already has existing images. You are being asked to confirm whether to delete the existing images and rescan, or to only look for new images.',
+		);
+		break;
 	}
 
 	$subTabs['pp_sets'] = array(
@@ -1804,16 +1995,22 @@ function pp_output_tabs($current, $threadTitle='', $tid=0)
 		'description' => $lang->pp_admin_sets_desc,
 	);
 
+	$subTabs['pp_image_tasks'] = array(
+		'title' => 'Image Tasks',
+		'link' => $html->url(array('action' => 'image_tasks')),
+		'description' => 'view and manage image tasks',
+	);
+
 	$subTabs['pp_image_task_lists'] = array(
 		'title' => 'Image Task Lists',
 		'link' => $html->url(array('action' => 'image_task_lists')),
 		'description' => 'view and manage image tasks',
 	);
 
-	$subTabs['pp_image_tasks'] = array(
-		'title' => 'Image Tasks',
-		'link' => $html->url(array('action' => 'image_tasks')),
-		'description' => 'view and manage image tasks',
+	$subTabs['pp_scan_center'] = array(
+		'title' => 'Scan Center',
+		'link' => $html->url(array('action' => 'scan_center')),
+		'description' => 'scan the forum for images',
 	);
 
 	$page->output_nav_tabs($subTabs, $current);
@@ -1829,7 +2026,7 @@ function pp_output_tabs($current, $threadTitle='', $tid=0)
  */
 function ppBuildForumList(&$table, $pid=0, $depth=1)
 {
-	global $mybb, $lang, $db, $sub_forums;
+	global $mybb, $lang, $db, $sub_forums, $html;
 	static $allForums;
 
 	// load the forum cache if necessary
@@ -1858,6 +2055,7 @@ function ppBuildForumList(&$table, $pid=0, $depth=1)
 				$table->construct_cell("<div style=\"padding-left: ".(10*($depth-1))."px;\"><strong>{$forum['name']}</strong></div>");
 				$table->construct_cell("<span style=\"font-style: italic;\">{$forum['description']}</span>");
 				$table->construct_cell('');
+				$table->construct_cell('');
 				$table->construct_row();
 
 				// Does this category have any sub forums?
@@ -1881,6 +2079,10 @@ function ppBuildForumList(&$table, $pid=0, $depth=1)
 				$table->construct_cell("<div style=\"{$forumNameStyle}padding-left: ".(10*($depth-1))."px;\">{$forumLink}</div>");
 				$table->construct_cell("<span style=\"font-style: italic;\">{$forum['description']}</span>");
 				$table->construct_cell("<span style=\"{$imageCountStyle}\">{$imageCount}</span>");
+
+				$popup = new PopupMenu("control_{$forum['fid']}", 'Options');
+				$popup->add_item('Scan', $html->url(array('action' => 'scan_center', 'mode' => 'inline', 'fid' => $forum['fid'])));
+				$table->construct_cell($popup->fetch());
 
 				$table->construct_row();
 

--- a/Upload/inc/plugins/pp/acp.php
+++ b/Upload/inc/plugins/pp/acp.php
@@ -588,13 +588,19 @@ EOF;
 			$query = $db->simple_select('pp_images', 'COUNT(id) as image_count', "setid={$id}");
 			$imageCount = $db->fetch_field($query, 'image_count');
 
+			$editUrl = $html->url(array('action' => 'edit_set', 'id' => $id, 'my_post_key' => $mybb->post_code));
+
 			$deleteUrl = $html->url(array('action' => 'sets', 'mode' => 'delete', 'id' => $id, 'my_post_key' => $mybb->post_code));
-			$deleteLink = $html->link($deleteUrl, $lang->pp_delete);
 
 			$table->construct_cell($html->link($html->url(array('action' => 'view_set', 'id' => $id)), $imageSet['title']));
 			$table->construct_cell($imageSet['description']);
 			$table->construct_cell($imageCount);
-			$table->construct_cell($deleteLink);
+
+			$popup = new PopupMenu("control_{$id}", 'Options');
+			$popup->add_item('Edit', $editUrl);
+			$popup->add_item($lang->pp_delete, $deleteUrl);
+			$table->construct_cell($popup->fetch());
+
 			$table->construct_cell($form->generate_check_box("pp_inline_ids[{$id}]", '', '', array('class' => 'pp_check')));
 			$table->construct_row();
 		}

--- a/Upload/inc/plugins/pp/acp.php
+++ b/Upload/inc/plugins/pp/acp.php
@@ -161,7 +161,8 @@ EOF;
 EOF;
 
 	$table = new Table;
-	$table->construct_header($lang->pp_thread, array('width' => '70%'));
+	$table->construct_header($lang->pp_thread, array('width' => '50%'));
+	$table->construct_header('Thread Link', array('width' => '20%'));
 	$table->construct_header($lang->pp_image_count, array('width' => '15%'));
 	$table->construct_header('Controls', array('width' => '10%'));
 	$table->construct_header($form->generate_check_box('', '', '', array('id' => 'pp_select_all')), array('style' => 'width: 1%'));
@@ -207,6 +208,11 @@ EOF;
 	if ($db->num_rows($query) > 0) {
 		while ($thread = $db->fetch_array($query)) {
 			$table->construct_cell($html->link($html->url(array('action' => 'view_thread', 'tid' => $thread['tid'])), $thread['subject']));
+
+			$threadUrl = '../'.get_thread_link($thread['tid']);
+			$threadLink = $html->link($threadUrl, "#{$thread['tid']}", array('target' => '_blank'));
+			$table->construct_cell($threadLink);
+
 			$table->construct_cell($thread['image_count']);
 
 			$popup = new PopupMenu("control_{$thread['tid']}", 'Options');

--- a/Upload/inc/plugins/pp/functions.php
+++ b/Upload/inc/plugins/pp/functions.php
@@ -407,4 +407,60 @@ function ppCleanPath($path, $preOnly=false)
 	return $path;
 }
 
+/**
+ * remove protocol if given and trim if query if applicable
+ *
+ * @param  string
+ * @return string clean path
+ */
+function ppCleanDomain($domain='')
+{
+	if (!$domain) {
+		return '';
+	}
+
+	$hostname = str_replace(array('http://', 'https://'), '', $domain);
+
+	if (!$hostname) {
+		return '';
+	}
+
+	$hostname_array = explode('/', $hostname);
+
+	if (count($hostname_array) == 0) {
+		return '';
+	}
+
+	$hostname = $hostname_array[0];
+	if (!$hostname) {
+		return '';
+	}
+
+	return $hostname;
+}
+
+/**
+ * trim domain string and check to see that it exists
+ *
+ * @param  string
+ * @return string clean path
+ */
+function ppValidateDomain($domain)
+{
+	$domain = ppCleanDomain($domain);
+
+	if (!$domain) {
+		return false;
+	}
+
+	$resolved_ip = gethostbyname($hostname);
+
+	// gethostbyname returns the given string on error
+	if ($resolved_ip == $hostname) {
+		return false;
+	}
+
+	return true;
+}
+
 ?>

--- a/Upload/inc/plugins/pp/modules/imgur_rehost.php
+++ b/Upload/inc/plugins/pp/modules/imgur_rehost.php
@@ -62,6 +62,7 @@ function pp_imgur_rehost_process_images($images, $settings)
 	$redirectInfo = array(
 		'action' => 'view_thread',
 		'tid' => $tid,
+		'page' => $mybb->input['page'],
 	);
 
 	// main loop - process the images

--- a/Upload/inc/plugins/pp/modules/local_rehost.php
+++ b/Upload/inc/plugins/pp/modules/local_rehost.php
@@ -121,6 +121,8 @@ function pp_local_rehost_process_images($images, $settings)
 
 		if ($ext == 'jpeg') {
 			$ext = 'jpg';
+		} elseif (!$ext) {
+			$ext = 'png';
 		}
 
 		$filename = "{$path}/{$baseName}.{$ext}";

--- a/Upload/inc/plugins/pp/modules/local_rehost.php
+++ b/Upload/inc/plugins/pp/modules/local_rehost.php
@@ -68,6 +68,7 @@ function pp_local_rehost_process_images($images, $settings)
 	$redirectInfo = array(
 		'action' => 'view_thread',
 		'tid' => $tid,
+		'page' => $mybb->input['page'],
 	);
 
 	// build path

--- a/Upload/inc/plugins/pp/modules/local_rehost.php
+++ b/Upload/inc/plugins/pp/modules/local_rehost.php
@@ -66,7 +66,7 @@ function pp_local_rehost_process_images($images, $settings)
 	// set up redirect
 	$tid = $images[key($images)]['tid'];
 	$redirectInfo = array(
-		'action' => 'view_set',
+		'action' => 'view_thread',
 		'tid' => $tid,
 	);
 

--- a/Upload/inc/plugins/pp/modules/local_rehost.php
+++ b/Upload/inc/plugins/pp/modules/local_rehost.php
@@ -25,9 +25,15 @@ function pp_local_rehost_info()
 		'settings' => array(
 			'path' => array(
 				'title' => 'Path',
-				'description' => 'URL relative to the forum root where the rehosted images should be stored',
+				'description' => 'location relative to the forum root where the rehosted images should be stored (eg. images or myimages/rehost)',
 				'optionscode' => 'text',
 				'value' => 'images/picture_perfect/rehost',
+			),
+			'domain' => array(
+				'title' => 'Domain',
+				'description' => 'leave this setting blank to use the board URL or enter a new domain here (useful for rehosting images to a subdomain) eg. http://images.myforum.com',
+				'optionscode' => 'text',
+				'value' => '',
 			),
 			'format' => array(
 				'title' => 'Image File Format',
@@ -65,6 +71,17 @@ function pp_local_rehost_process_images($images, $settings)
 	);
 
 	// build path
+	$domain = $settings['domain'];
+	if (!$domain) {
+		$domain = $mybb->settings['bburl'];
+	}
+
+	$domain = ppCleanPath($domain);
+	if ($domain != $mybb->settings['bburl'] &&
+		!ppValidateDomain($domain)) {
+		$domain = $mybb->settings['bburl'];
+	}
+
 	$basePath = ppCleanPath($settings['path']);
 	$path = MYBB_ROOT.$basePath;
 
@@ -139,7 +156,7 @@ function pp_local_rehost_process_images($images, $settings)
 		@imagedestroy($image['image']);
 
 		// now swap the image URL in the post
-		$url = "{$mybb->settings['bburl']}/{$basePath}/{$baseName}.{$ext}";
+		$url = "{$domain}/{$basePath}/{$baseName}.{$ext}";
 		if (!ppReplacePostImage($image['pid'], $image['url'], $url)) {
 			$fail++;
 		} else {


### PR DESCRIPTION
**Changes:**

- adds the option to skip the initial scan
- adds the option to scan individual threads and/or forums
- adds the option to rehost images to a subdomain
- adds a link to the thread in View Threads page for easy access
- adds navigation breadcrumbs

**Fixes:**

- a bug where a missing language file caused the task to fail
- a bug where when rehosting images, the user was redirected to the View Image Set page rather than the View Thread page
- a bug where valid images that did not have an extension appended to the file name caused locally rehosting images to fail
- a bug where redirects did not return the user to the original page
- a bug where it was impossible to edit image sets once they were created
